### PR TITLE
Updated file rows in assert so to fit with updated dataset.

### DIFF
--- a/Scripts/RBP/Eclip/Snakefile
+++ b/Scripts/RBP/Eclip/Snakefile
@@ -14,7 +14,7 @@ ECLIP_MODEL_SCRIPTS = ["kmer_glmnet"]
 import pandas as pd
 dt = pd.read_table("data/eclip/raw/metadata.tsv")
 RBPS = pd.Series([x[0] for x in dt[dt.Assembly == "GRCh38"]["Experiment target"].str.split("-")]).unique()
-assert len(RBPS) == 112
+assert len(RBPS) == 150
 
 RBP_SUBSET = ["UPF1", "PUM2", "DDX3X", "NKRF", "TARDBP", "SUGP2"]
 

--- a/Scripts/RBP/Eclip/Snakefile
+++ b/Scripts/RBP/Eclip/Snakefile
@@ -14,7 +14,8 @@ ECLIP_MODEL_SCRIPTS = ["kmer_glmnet"]
 import pandas as pd
 dt = pd.read_table("data/eclip/raw/metadata.tsv")
 RBPS = pd.Series([x[0] for x in dt[dt.Assembly == "GRCh38"]["Experiment target"].str.split("-")]).unique()
-assert len(RBPS) == 150
+
+assert len(RBPS) in [112, 150]  # support either the new or the old version
 
 RBP_SUBSET = ["UPF1", "PUM2", "DDX3X", "NKRF", "TARDBP", "SUGP2"]
 


### PR DESCRIPTION
The new metadata file found in `data/eclip/raw/metadata.tsv` has now 150 rows, not 112 as the original one. As pointed out in the open issue, this will cause for an `AssertionError` to be raised. 

To allow for easier future reproducibility, I've proceeded to edit the file myself, hoping it will be merged with the main repository.