### PR TITLE
Updated fasta files paths.

### DIFF
--- a/Scripts/RBP/Eclip/Snakefile
+++ b/Scripts/RBP/Eclip/Snakefile
@@ -48,8 +48,8 @@ rule all:
 rule process_raw_data:
     input:
         "data/eclip/raw/metadata.tsv",
-        "/s/genomes/human/hg38/GRCh38.p7/gencode.v25.annotation.gtf.rds",
-        "/s/genomes/human/hg38/GRCh38.p7/GRCh38.p7.genome.fa",
+        "fasta/gencode.v25.annotation.gtf.rds",
+        "fasta7/GRCh38.p7.genome.fa",
         SRC + "0_match_peaks_genes.R"
     output:
         "data/eclip/processed/protein_peak_overlaps.rds",
@@ -60,7 +60,7 @@ rule process_raw_data:
 rule append_sequence:
     input:
         "data/eclip/processed/peak_center-gene_mapping.rds",
-        "/s/genomes/human/hg38/GRCh38.p7/GRCh38.p7.genome.fa",
+        "fasta/GRCh38.p7.genome.fa",
         SRC + "1_extract_peak_sequence.R"
     output:
         "data/eclip/processed/peak_center-gene_mapping_with_sequence.rds"


### PR DESCRIPTION
Previously, the fasta files were relative to the root of the system were the project was run. Now they are relative to the repository, in the path that I have indicated in the readme, so to facilitate reproducibility.