### PR TITLE
Fixed empty list issue.

### DIFF
--- a/Scripts/functions/avsec_utils/granges.R
+++ b/Scripts/functions/avsec_utils/granges.R
@@ -233,7 +233,7 @@ reverseComplement_char <- function(seq) {
 ##' You have to wrap `Views(seq[[chr]],ranges(gr_list[[chr]]))` with `DNAStringSet`
 easy_Views <- function(seq, gr, reverse_seq = TRUE, colname = "seq") {
   gr_list <- split(gr, seqnames(gr))
-
+  names(seq) <- paste("chr", names(seq), sep='')
   gr_list <- lapply(intersect(names(seq),names(gr_list)) , function(chr) {
     gr_tmp <- gr_list[[chr]]
     v <- Views(seq[[chr]],ranges(gr_list[[chr]]))


### PR DESCRIPTION
Using the given `.tab` and `fasta` datasets, the chromosomes were represented as `chr{chromosome}`, for example `chr1` or `chrX`. In the `seq` list the chromosomes were represented as `1`, `2`, ..., `X`,`Y`, so when the `intersect` function between the two sets was called, the result was an empty list. As solution is proposed to prepend `chr` to the chromosome names in the `seq` list.