### PR TITLE
Fixed issue with tinker/matplotlib.

### DIFF
--- a/Scripts/Splice_branchpoints/postprocess.py
+++ b/Scripts/Splice_branchpoints/postprocess.py
@@ -5,6 +5,8 @@
 - get validation accuracies
 """
 import os
+import matplotlib
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 from concise.hyopt import CompileFN, CMongoTrials, test_fn
 import numpy as np


### PR DESCRIPTION
Basically, `agg` come install on most machine, but `TK` that is the default module that handles plotting doesn't, so for example on the server I'm using the import fails.